### PR TITLE
Set x-openclaw-message-channel header for voice requests

### DIFF
--- a/custom_components/openclaw/conversation.py
+++ b/custom_components/openclaw/conversation.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 _VOICE_REQUEST_HEADERS = {
     "x-openclaw-source": "voice",
     "x-ha-voice": "true",
+    "x-openclaw-message-channel": "voice",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `x-openclaw-message-channel: voice` to `_VOICE_REQUEST_HEADERS` in `conversation.py`

## Problem

The OpenClaw gateway injects a `channel=webchat` value into the agent's Runtime context for all chat completions API requests. This causes the agent to believe it's in a text chat session, even when the request originates from HA Assist voice. The agent sees `channel=webchat` in its system prompt and ignores voice-specific formatting instructions.

## Fix

The OpenClaw gateway supports an `x-openclaw-message-channel` header that overrides the default channel context. The integration already sends `x-openclaw-source: voice` and `x-ha-voice: true`, but these don't change what the agent sees in its Runtime line. Adding `x-openclaw-message-channel: voice` makes the Runtime show `channel=voice`, allowing the agent to correctly identify voice sessions and apply TTS-appropriate formatting.

## Test plan

- [ ] Start HA Assist voice session → agent Runtime shows `channel=voice` instead of `channel=webchat`
- [ ] Agent applies voice-specific skills/formatting when session is voice
- [ ] Non-voice interactions (Lovelace chat card) remain unaffected