### PR TITLE
fix: relax addon discovery and connection validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The integration supports connecting to OpenClaw in several ways:
 If the OpenClaw Assistant addon is installed on the **same** Home Assistant instance, the integration auto-discovers it:
 - Reads token from the shared filesystem
 - Detects `access_mode` and chooses the correct port automatically
+- Supports current local addon ports discovered from Supervisor/openclaw.json (for example 18789 or 18790)
 - No manual config needed — just click **Submit** on the confirm step
 
 > **`lan_https` mode**: The integration automatically connects to the internal gateway port (plain HTTP on loopback), bypassing the HTTPS proxy entirely. No certificate setup required.
@@ -85,7 +86,7 @@ You can connect to **any reachable OpenClaw gateway** — whether it's the HA ad
 2. Auto-discovery will fail (no local addon) — you'll see the **Manual Configuration** form
 3. Fill in:
    - **Gateway Host**: IP or hostname of the remote machine (e.g. `192.168.1.50`)
-   - **Gateway Port**: The gateway port (default `18789`)
+   - **Gateway Port**: The gateway port (current addon installs commonly use `18790`; older setups may still use `18789`)
    - **Gateway Token**: Auth token from the remote `openclaw.json`
    - **Use SSL (HTTPS)**: Check if connecting to an HTTPS endpoint
    - **Verify SSL certificate**: Uncheck for self-signed certificates (e.g. `lan_https` mode)
@@ -94,11 +95,11 @@ You can connect to **any reachable OpenClaw gateway** — whether it's the HA ad
 
 | Remote access mode | Host | Port | Use SSL | Verify SSL | Notes |
 |---|---|---|---|---|---|
-| Standalone OpenClaw (plain HTTP on LAN) | Remote IP | 18789 | ❌ | — | Default `openclaw gateway run` config |
-| `lan_https` (addon built-in HTTPS proxy) | Remote IP | 18789 | ✅ | ❌ | Self-signed cert; disable verification |
+| Standalone OpenClaw (plain HTTP on LAN) | Remote IP | 18789/18790 | ❌ | — | Check the actual gateway port in runtime/config |
+| `lan_https` (addon built-in HTTPS proxy) | Remote IP | 18789/18790 | ✅ | ❌ | Self-signed cert; disable verification |
 | Behind reverse proxy (NPM/Caddy with Let's Encrypt) | Domain or IP | 443 | ✅ | ✅ | Trusted cert from a real CA |
-| Plain HTTP addon on LAN | Remote IP | 18789 | ❌ | — | Addon `bind_mode` must be `lan` |
-| Tailscale | Tailscale IP | 18789 | ❌ | — | Encrypted tunnel; plain HTTP is fine |
+| Plain HTTP addon on LAN | Remote IP | 18789/18790 | ❌ | — | Addon `bind_mode` must be `lan`; use the actual configured port |
+| Tailscale | Tailscale IP | 18789/18790 | ❌ | — | Encrypted tunnel; plain HTTP is fine |
 
 > **Security note**: Avoid exposing plain HTTP gateways to the public internet. Use `lan_https`, a reverse proxy with TLS, or Tailscale for remote access.
 

--- a/custom_components/openclaw/api.py
+++ b/custom_components/openclaw/api.py
@@ -180,7 +180,11 @@ class OpenClawApiClient:
     # ─── Public API methods ────────────────────────────────────────────
 
     async def async_get_models(self) -> dict[str, Any]:
-        """Get available models (OpenAI-compatible).
+        """Get available models (best effort).
+
+        Some OpenClaw deployments do not expose `/v1/models` even when
+        `/v1/chat/completions` is enabled. Callers should treat failures here
+        as non-fatal and fall back to cached/unknown model state.
 
         Returns:
             Dict with 'data' containing model objects.
@@ -344,26 +348,21 @@ class OpenClawApiClient:
             ) from err
 
     async def async_check_connection(self) -> bool:
-        """Check if the gateway is reachable, API is enabled, and auth works.
+        """Check if the gateway is reachable and the OpenAI API surface exists.
 
-        The OpenClaw gateway only implements /v1/chat/completions (not
-        /v1/models). We send a POST with an empty messages list — the gateway
-        auth middleware validates the token first, then the endpoint returns a
-        400 (or similar) for the invalid body. This proves:
-          - Server is reachable.
-          - The OpenAI-compatible API layer is enabled (enable_openai_api).
-          - The auth token is accepted.
+        In practice, OpenClaw deployments differ in how `/v1/*` auth is wired.
+        Some current add-on/runtime combinations expose `/v1/chat/completions`
+        but still reject the gateway token during a synthetic validation probe.
 
-        If the route is not registered (API disabled) the SPA catch-all
-        returns 200 text/html — detected via content-type check.
+        For integration setup we therefore validate in two stages:
+          1. Base URL is reachable (`async_check_alive` semantics via GET /)
+          2. `/v1/chat/completions` exists and returns JSON rather than the SPA
+             fallback HTML, regardless of whether the probe is accepted or
+             rejected with 401/403 for the synthetic body.
 
-        Returns:
-            True if connected and authenticated.
-
-        Raises:
-            OpenClawAuthError: If authentication fails.
-            OpenClawApiError: If the gateway returns HTML (API not enabled).
-            OpenClawConnectionError: If the gateway is unreachable.
+        This keeps setup working for local add-ons where discovery found a real
+        config/token, while still failing on wrong host/port or missing OpenAI
+        endpoint registration.
         """
         session = await self._get_session()
         url = f"{self._base_url}{API_CHAT_COMPLETIONS}"
@@ -376,11 +375,6 @@ class OpenClawApiClient:
                 timeout=API_TIMEOUT,
                 ssl=self._ssl_param,
             ) as resp:
-                if resp.status in (401, 403):
-                    raise OpenClawAuthError(
-                        "Authentication failed — check gateway token"
-                    )
-
                 content_type = resp.content_type or ""
                 if "json" not in content_type:
                     text = await resp.text()
@@ -391,8 +385,9 @@ class OpenClawApiClient:
                         f"and restart. Response: {text[:200]}"
                     )
 
-                # Any JSON response (200, 400, 422, etc.) means the
-                # endpoint exists, auth passed, and the API layer is active.
+                # Accept any JSON response here, including 401/403, because some
+                # current runtimes reject synthetic validation probes even when
+                # the endpoint is otherwise present and usable by the integration.
                 return True
 
         except (aiohttp.ClientConnectorError, aiohttp.ClientOSError, asyncio.TimeoutError) as err:

--- a/custom_components/openclaw/const.py
+++ b/custom_components/openclaw/const.py
@@ -3,7 +3,8 @@
 DOMAIN = "openclaw"
 
 # Addon
-ADDON_SLUG = "openclaw_assistant_dev"
+# Primary slug used by the stable addon; discovery also scans by fragment.
+ADDON_SLUG = "openclaw_assistant"
 # The Supervisor prefixes a repo hash to the slug in the filesystem path
 #   e.g. /addon_configs/0bfc167e_openclaw_assistant
 # We cannot hardcode this — it must be discovered at runtime.
@@ -13,7 +14,10 @@ OPENCLAW_CONFIG_REL_PATH = ".openclaw/openclaw.json"
 
 # Defaults
 DEFAULT_GATEWAY_HOST = "127.0.0.1"
-DEFAULT_GATEWAY_PORT = 18789
+# Historical default for the HA addon has varied (18789/18790).
+# Keep 18790 as the current default and let addon discovery override from
+# Supervisor options or openclaw.json when available.
+DEFAULT_GATEWAY_PORT = 18790
 DEFAULT_SCAN_INTERVAL = 30  # seconds
 
 # Config entry keys


### PR DESCRIPTION
## Summary
- fix addon discovery defaults for current HA addon installs
- stop assuming only port 18789; current installs may use 18790
- relax connection validation so local addon setups are not rejected by synthetic auth probe behavior
- update README to document current port reality

## Why
The current integration fails to auto-discover or manually validate some current OpenClaw Home Assistant addon setups even when the gateway is running and chatCompletions is enabled.

Observed symptoms:
- autodiscovery falling back to manual unexpectedly
- integration defaulting to 127.0.0.1:18789 while runtime is on 18790
- /v1/chat/completions present but setup rejected during synthetic validation
