### PR TITLE
Bump version to 0.1.62 and backfill changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the OpenClaw Home Assistant Integration will be documented in this file.
 
+## [0.1.62] - 2026-04-04
+
+### Added
+- Added `continue_conversation` heuristics for Assist / Voice PE follow-up dialog so voice satellites can automatically re-listen when the assistant asks a follow-up question. (Merged PR #11)
+- Added `x-openclaw-message-channel: voice` on voice pipeline requests so the OpenClaw runtime can identify Assist sessions as voice instead of generic webchat. (Merged PR #13)
+
+### Fixed
+- Fixed the **Active Model** select entity so the selected model is actually passed to both chat-card and Assist requests.
+- Fixed manifest documentation and issue-tracker links so they point to the integration repository instead of the add-on repository.
+- Fixed chat-card cache-busting/version drift by aligning backend resource registration and the root loader shim with the current integration version.
+- Fixed event entity lifecycle handling by moving event-bus subscriptions into `async_added_to_hass`.
+- Fixed potential cross-agent Assist context bleed by namespacing fallback conversation IDs with the selected agent ID.
+
+### Changed
+- Removed the unsupported `attachments` field from `openclaw.send_message` service schema/docs/translations because it was accepted by the integration but never sent to the gateway.
+- Extracted shared recursive response-text parsing into `helpers.py` to remove duplicated logic.
+- Added a warning when the API client has to create a fallback aiohttp session because the primary Home Assistant-managed session is no longer available.
+- Updated README documentation to reflect current model-selection, event-entity, and service behavior.
+
 ## [0.1.61] - 2026-03-07
 
 ### Added

--- a/custom_components/openclaw/__init__.py
+++ b/custom_components/openclaw/__init__.py
@@ -107,7 +107,7 @@ _CARD_PATH = Path(__file__).parent / "www" / _CARD_FILENAME
 # URL at which the card JS is served (registered via register_static_path)
 _CARD_STATIC_URL = f"/openclaw/{_CARD_FILENAME}"
 # Versioned URL used for Lovelace resource registration to avoid stale browser cache
-_CARD_URL = f"{_CARD_STATIC_URL}?v=0.1.61"
+_CARD_URL = f"{_CARD_STATIC_URL}?v=0.1.62"
 
 OpenClawConfigEntry = ConfigEntry
 

--- a/custom_components/openclaw/manifest.json
+++ b/custom_components/openclaw/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/techartdev/OpenClawHomeAssistantIntegration/issues",
   "requirements": [],
-  "version": "0.1.61",
+  "version": "0.1.62",
   "dependencies": ["conversation"],
   "after_dependencies": ["hassio", "lovelace"]
 }

--- a/www/openclaw-chat-card.js
+++ b/www/openclaw-chat-card.js
@@ -1,7 +1,7 @@
 (async () => {
   try {
     if (!customElements.get("openclaw-chat-card")) {
-      const src = "/openclaw/openclaw-chat-card.js?v=0.1.61";
+      const src = "/openclaw/openclaw-chat-card.js?v=0.1.62";
       console.info("OpenClaw loader importing", src);
       await import(src);
     }


### PR DESCRIPTION
## Summary

Follow-up release hygiene PR after #18.

### Included
- bump integration version from **0.1.61** to **0.1.62**
- bump chat-card cache-busting URL in backend resource registration
- bump root loader shim cache-busting URL
- add a new **0.1.62** changelog entry
- backfill changelog coverage for the already-merged work from:
  - **PR #11** (`continue_conversation`)
  - **PR #13** (`x-openclaw-message-channel: voice`)
  - **PR #18** (model selector fix, docs links, cache-busting alignment, lifecycle cleanup, agent-aware conversation ID namespacing, docs cleanup)

## Why

The code changes were merged, but the release version and changelog were left behind. This PR just brings release metadata back in sync.