### PR TITLE
conversation: scrub OpenClaw tool_code fences before TTS

### DIFF
--- a/custom_components/openclaw/conversation.py
+++ b/custom_components/openclaw/conversation.py
@@ -44,6 +44,23 @@ from .helpers import extract_text_recursive
 
 _LOGGER = logging.getLogger(__name__)
 
+# Strip OpenClaw ```tool_code``` markdown fences from the response text before
+# it reaches the Assist pipeline / TTS. The OpenClaw family-memory plugin
+# bridge rewrites these fences in the persisted transcript and fires the DB
+# write, but the response payload from /v1/chat/completions bypasses all
+# plugin hooks (before_message_write fires on persistence only). Without this
+# scrubber Voice PE TTS would speak the raw call literally.
+_TOOL_CODE_FENCE_RE = re.compile(r"```tool_code\s*\n.*?\n?```", re.DOTALL)
+
+
+def _scrub_tool_code_fences(text: str) -> str:
+    """Replace ```tool_code``` fences with a short confirmation for TTS."""
+    if not text:
+        return text
+    scrubbed = _TOOL_CODE_FENCE_RE.sub("", text).strip()
+    return scrubbed if scrubbed else "OK."
+
+
 _VOICE_REQUEST_HEADERS = {
     "x-openclaw-source": "voice",
     "x-ha-voice": "true",
@@ -282,7 +299,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
             full_response += chunk
 
         if full_response:
-            return full_response
+            return _scrub_tool_code_fences(full_response)
 
         response = await client.async_send_message(
             message=message,
@@ -292,7 +309,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
             agent_id=agent_id,
             extra_headers=_VOICE_REQUEST_HEADERS,
         )
-        return extract_text_recursive(response) or ""
+        return _scrub_tool_code_fences(extract_text_recursive(response) or "")
 
     @staticmethod
     def _should_continue(response: str) -> bool:


### PR DESCRIPTION
## Summary

Strip ` ``` `tool_code` ``` ` markdown fences from conversation responses before they reach the Assist pipeline.

When OpenClaw is paired with a workspace plugin that handles tool calls via gemma3-style fences (e.g., a custom `record_fact` tool in a personal-memory plugin), Voice PE TTS literally speaks the raw call: *"record underscore fact open paren person underscore slug equals quote..."*. OpenClaw's plugin hook system rewrites the *persisted* transcript via `before_message_write`, but `result.payloads` is built directly from raw LLM output upstream of any hook — verified empirically with `stream:false` (the response payload still surfaces the raw fence even when persistence-side bridges have logged the rewrite). The architectural fix would belong upstream in `openclaw/openclaw` (firing `before_message_write` on `result.payloads` too, or a new `before_response_finalize` hook); this PR is a localized HA-side scrub.

The scrubber is 15 lines, no new dependencies, applied symmetrically on both the streaming and non-streaming response paths in `_get_response`. Behavior:

- Fence-only output (typical for `record_fact`-style turns) → `"OK."`
- Mixed response (text before/after fence) → fence stripped, surrounding text preserved
- Normal responses without fences → unchanged

## Test plan

- [x] `record_fact`-triggering prompt round-tripped through `/api/services/conversation/process?return_response=true`: `speech.plain.speech` is `"OK."` (was raw fence)
- [x] Normal query "What is son1 favorite color?" round-trips unchanged: `"Son1's favorite color is blue. Source: family_db#son1.favorites.color"`
- [x] HA integration loads clean after restart, no new warnings (the existing line-316 SyntaxWarning is unrelated)
- [x] Underlying DB write still fires (the persistence-path bridge is unaffected — verified via gateway journal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)