### PR TITLE
Fix invalid \\] escape sequence in conversation.py regex

### DIFF
--- a/custom_components/openclaw/conversation.py
+++ b/custom_components/openclaw/conversation.py
@@ -313,7 +313,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
 
         # Check if the response ends with a question mark
         # (allow trailing punctuation like quotes, parens, or emoji)
-        if re.search(r"\?\s*[\"'""»)\]]*\s*$", text):
+        if re.search(r"\?\s*[\"'»)\]]*\s*$", text):
             return True
 
         # Common follow-up patterns (EN + DE)


### PR DESCRIPTION
## Summary

The regex literal at `custom_components/openclaw/conversation.py:316` is parsed by Python as **two adjacent string literals** rather than one. The second of those literals is non-raw and contains `\]`, which Python 3.12+ flags as `SyntaxWarning: invalid escape sequence '\]'` and which Python 3.14 promotes to `SyntaxError`.

```py
# Before — splits into r"\?\s*[\"'" + "»)\]]*\s*$" because the inner "" closes
# the raw string and reopens a non-raw one. The non-raw half then contains \].
if re.search(r"\?\s*[\"'""»)\]]*\s*$", text):

# After — single raw string, identical regex semantics.
if re.search(r"\?\s*[\"'»)\]]*\s*$", text):
```

The compiled regex character class is identical (`["'»)\]]`); only the Python source representation changes. The redundant inner `""` was a no-op concatenation seam, not a deliberate character.

## Verification

- `python -W error::SyntaxWarning -c "import py_compile; py_compile.compile('conversation.py', doraise=True)"` — passes after the fix, fails before.
- Regex still matches `Are you sure?`, `Are you sure? "`, `Are you sure? »`, `Are you sure?)` and rejects `Statement.` (verified locally).
- One-line change, scoped to a cosmetic style fix; orthogonal to PR #26 (behavioral scrubber change).

## Test plan

- [ ] CI / maintainer's local Python ≥ 3.12 no longer emits the `SyntaxWarning` on import of `conversation.py`.
- [ ] No behavior change in `_is_likely_question_followup` follow-up detection.