### PR TITLE
Roll up safe community fixes for Assist routing and TTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the OpenClaw Home Assistant Integration will be documented in this file.
 
+## [0.1.63] - 2026-05-31
+
+### Fixed
+- Fixed Assist/TTS reading raw ```tool_code``` fences aloud by scrubbing those fenced tool-call payloads from conversation responses before they reach Home Assistant speech output. (Based on PR #26 by @tundakk)
+- Fixed a Python regex literal in the Assist follow-up heuristic that raises `SyntaxWarning` on Python 3.12+ and becomes a `SyntaxError` on Python 3.14. (Based on PR #27 by @tundakk)
+- Fixed agent routing fallback for chat-completions requests by sending `model: openclaw:<agent_id>` whenever an agent is selected and no explicit model override is set. (Based on PR #10 by @dalehamel)
+
 ## [0.1.62] - 2026-04-04
 
 ### Added

--- a/custom_components/openclaw/__init__.py
+++ b/custom_components/openclaw/__init__.py
@@ -107,7 +107,7 @@ _CARD_PATH = Path(__file__).parent / "www" / _CARD_FILENAME
 # URL at which the card JS is served (registered via register_static_path)
 _CARD_STATIC_URL = f"/openclaw/{_CARD_FILENAME}"
 # Versioned URL used for Lovelace resource registration to avoid stale browser cache
-_CARD_URL = f"{_CARD_STATIC_URL}?v=0.1.62"
+_CARD_URL = f"{_CARD_STATIC_URL}?v=0.1.63"
 
 OpenClawConfigEntry = ConfigEntry
 

--- a/custom_components/openclaw/api.py
+++ b/custom_components/openclaw/api.py
@@ -232,6 +232,8 @@ class OpenClawApiClient:
             payload["user"] = session_id
         if model:
             payload["model"] = model
+        elif agent_id:
+            payload["model"] = f"openclaw:{agent_id}"
 
         # Pass session_id as a custom header or param if supported by gateway
         headers = self._headers(agent_id=agent_id, extra_headers=extra_headers)
@@ -299,6 +301,8 @@ class OpenClawApiClient:
             payload["user"] = session_id
         if model:
             payload["model"] = model
+        elif agent_id:
+            payload["model"] = f"openclaw:{agent_id}"
 
         headers = self._headers(agent_id=agent_id, extra_headers=extra_headers)
         if session_id:

--- a/custom_components/openclaw/conversation.py
+++ b/custom_components/openclaw/conversation.py
@@ -44,6 +44,19 @@ from .helpers import extract_text_recursive
 
 _LOGGER = logging.getLogger(__name__)
 
+# Strip OpenClaw ```tool_code``` markdown fences from the response text before
+# it reaches the Assist pipeline / TTS. Some plugins rewrite these fences only
+# on the persisted transcript path, not on the immediate response payload.
+_TOOL_CODE_FENCE_RE = re.compile(r"```tool_code\s*\n.*?\n?```", re.DOTALL)
+
+
+def _scrub_tool_code_fences(text: str) -> str:
+    """Replace ```tool_code``` fences with a short confirmation for TTS."""
+    if not text:
+        return text
+    scrubbed = _TOOL_CODE_FENCE_RE.sub("", text).strip()
+    return scrubbed if scrubbed else "OK."
+
 _VOICE_REQUEST_HEADERS = {
     "x-openclaw-source": "voice",
     "x-ha-voice": "true",
@@ -282,7 +295,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
             full_response += chunk
 
         if full_response:
-            return full_response
+            return _scrub_tool_code_fences(full_response)
 
         response = await client.async_send_message(
             message=message,
@@ -292,7 +305,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
             agent_id=agent_id,
             extra_headers=_VOICE_REQUEST_HEADERS,
         )
-        return extract_text_recursive(response) or ""
+        return _scrub_tool_code_fences(extract_text_recursive(response) or "")
 
     @staticmethod
     def _should_continue(response: str) -> bool:
@@ -313,7 +326,7 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
 
         # Check if the response ends with a question mark
         # (allow trailing punctuation like quotes, parens, or emoji)
-        if re.search(r"\?\s*[\"'""»)\]]*\s*$", text):
+        if re.search(r"\?\s*[\"'»)\]]*\s*$", text):
             return True
 
         # Common follow-up patterns (EN + DE)

--- a/custom_components/openclaw/manifest.json
+++ b/custom_components/openclaw/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/techartdev/OpenClawHomeAssistantIntegration/issues",
   "requirements": [],
-  "version": "0.1.62",
+  "version": "0.1.63",
   "dependencies": ["conversation"],
   "after_dependencies": ["hassio", "lovelace"]
 }

--- a/www/openclaw-chat-card.js
+++ b/www/openclaw-chat-card.js
@@ -1,7 +1,7 @@
 (async () => {
   try {
     if (!customElements.get("openclaw-chat-card")) {
-      const src = "/openclaw/openclaw-chat-card.js?v=0.1.62";
+      const src = "/openclaw/openclaw-chat-card.js?v=0.1.63";
       console.info("OpenClaw loader importing", src);
       await import(src);
     }


### PR DESCRIPTION
## Summary
This rolls up the small, low-risk community fixes that still look worth merging on top of current `main`.

Included in this PR:
- scrub ` ```tool_code ` fences from Assist/TTS responses so Home Assistant does not speak raw tool-call payloads
- fix the invalid regex escape in the follow-up-question heuristic for Python 3.12+ / 3.14 compatibility
- add a conservative agent-routing fallback by sending `model: openclaw:<agent_id>` when an agent is selected and no explicit model override is set
- bump integration/card version to `0.1.63` and note the rollup in the changelog

## Validation
- `python3 -W error::SyntaxWarning -m py_compile custom_components/openclaw/*.py`
- small Python smoke checks for the fence scrubber, regex heuristic, and agent-model fallback

## Original community PRs quoted here
- #26 — conversation: scrub OpenClaw tool_code fences before TTS (@tundakk)
- #27 — Fix invalid `\]` escape sequence in conversation.py regex (@tundakk)
- #10 — feat(assist): sticky sessions and agent routing (@dalehamel)

I intentionally did **not** pull in the larger/invasive open PRs here; this is meant to be the safe consolidation pass.
